### PR TITLE
Ajout de la balise meta description

### DIFF
--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -8,6 +8,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="description" content="Open Collectivités centralise les données et publications statistiques sur les collectivités locales. Vous êtes agent public ? Trouvez les données concernant une collectivité et situez-la par rapport aux autres territoires. Vous êtes citoyen, journaliste ou chercheur ? Trouvez les publications statistiques classées par type de collectivité et par thématique." />
 
   {% dsfr_css %}
   {% dsfr_favicon %}


### PR DESCRIPTION
Description rédigée du portail Open Collectivités pour affichage en page de résultat des moteurs de recherche (fait partie de l'audit d'accessibilité).